### PR TITLE
crda: update regulatory.bin install patch

### DIFF
--- a/meta-networking/recipes-connectivity/crda/crda_3.18.bb
+++ b/meta-networking/recipes-connectivity/crda/crda_3.18.bb
@@ -29,13 +29,13 @@ do_compile() {
 do_install() {
     oe_runmake SBINDIR=${sbindir}/ install
 
-    install -d ${D}${libdir}/crda/
+    install -d ${D}${nonarch_libdir}/crda/
 
-    install -m 0644 ${WORKDIR}/wireless-regdb-2014.11.18/regulatory.bin ${D}${libdir}/crda/regulatory.bin
+    install -m 0644 ${WORKDIR}/wireless-regdb-2014.11.18/regulatory.bin ${D}${nonarch_libdir}/crda/regulatory.bin
 }
 
 
 RDEPENDS_${PN} = "udev"
-FILES_${PN} += "${libdir}crda/regulatory.bin \
+FILES_${PN} += "${nonarch_libdir}* \
                 ${base_libdir}/udev/rules.d/85-regulatory.rules \
 "


### PR DESCRIPTION
Issue: LINPUL8-666

Update regulatory.bin install variable from libdir to nonarch_libdir,
since the value of libdir is /usr/lib64 in x86-64 system, but crda
just check regulatory.bin in /usr/lib not /usr/lib64 by hard coding.

Signed-off-by: De Huo <De.Huo@windriver.com>